### PR TITLE
Drop postUrl as a config requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ var componentConfig = {
 };
 ```
 
+### Usage without automatic posting
+If you want to use this component without posting automatically to a URL but instead do the posting yourself, then you can just leave the `postUrl` option empty and handle the displaying of progress by yourself using the provided event handlers.
+
 Callbacks can be provided in an object literal. 
 
 ```js

--- a/lib/dropzone.js
+++ b/lib/dropzone.js
@@ -18,7 +18,6 @@ DropzoneComponent = React.createClass({displayName: "DropzoneComponent",
         var options,
             defaults = {
                 url: this.props.config.postUrl,
-                autoProcessQueue: this.props.config.autoProcessQueue,
                 headers: {
                     'Access-Control-Allow-Credentials': true,
                     'Access-Control-Allow-Headers': 'Content-Type, X-Requested-With, X-PINGOTHER, X-File-Name, Cache-Control',

--- a/lib/dropzone.js
+++ b/lib/dropzone.js
@@ -18,6 +18,7 @@ DropzoneComponent = React.createClass({displayName: "DropzoneComponent",
         var options,
             defaults = {
                 url: this.props.config.postUrl,
+                autoProcessQueue: this.props.config.autoProcessQueue,
                 headers: {
                     'Access-Control-Allow-Credentials': true,
                     'Access-Control-Allow-Headers': 'Content-Type, X-Requested-With, X-PINGOTHER, X-File-Name, Cache-Control',
@@ -49,7 +50,8 @@ DropzoneComponent = React.createClass({displayName: "DropzoneComponent",
             options = this.getDjsConfig();
 
         if (!this.props.config.postUrl && !this.props.eventHandlers.drop) {
-            console.info('Neither postUrl nor a "drop" eventHandler specified, the React-Dropzone component might misbehave.');
+            options.autoProcessQueue = false;
+            options.url = '/URL_TO_NOWHERE_AS_ITS_NOT_USED';
         }
 
         Dropzone.autoDiscover = false;


### PR DESCRIPTION
As discussed in #7 already, here is my suggested solution.

If `postUrl` is omitted in the configuration, the dropzone.js specific attribute `autoProcessQueue` is set to false and the `url` is set to some random string so that dropzone.js is not complaining.

Note that this is only one possible solution.
Since dropzone.js requires a defined configuration variable `url` we need to define something at least.

Another option would be to leave the configuration to the user and let him set url for itself (as it can either be a function or a string).
Though we would need to allow the react-dropzone-component user to set `autoProcessQueue` as a prop on our component.

