### PR TITLE
Add space when appending custom classNames

### DIFF
--- a/lib/dropzone.js
+++ b/lib/dropzone.js
@@ -72,7 +72,7 @@ DropzoneComponent = React.createClass({displayName: "DropzoneComponent",
         var icons = [],
             files = this.state.files,
             config = this.props.config,
-            className = (this.props.className) ? 'filepicker dropzone' + this.props.className : 'filepicker dropzone';
+            className = (this.props.className) ? 'filepicker dropzone ' + this.props.className : 'filepicker dropzone';
 
         if (config.showFiletypeIcon && config.allowedFiletypes && (!files || files.length < 1)) {
             for (var i = 0; i < this.props.config.allowedFiletypes.length; i = i + 1) {


### PR DESCRIPTION
When adding a custom className to the Dropzone component there should be a space to separate the base classNames from the new ones.

New:
```
<Dropzone className="customClass" .../>
```
Old:
```
<Dropzone className=" customClass" ... />
```
