### PR TITLE
remove headers and withCredentials defaults for cloudinary support

### DIFF
--- a/dist/dropzone.js
+++ b/dist/dropzone.js
@@ -21,14 +21,7 @@ DropzoneComponent = React.createClass({displayName: "DropzoneComponent",
     getDjsConfig: function () {
         var options,
             defaults = {
-                url: this.props.config.postUrl ? this.props.config.postUrl : null,
-                headers: {
-                    'Access-Control-Allow-Credentials': true,
-                    'Access-Control-Allow-Headers': 'Content-Type, X-Requested-With, X-PINGOTHER, X-File-Name, Cache-Control',
-                    'Access-Control-Allow-Methods': 'PUT, POST, GET, OPTIONS',
-                    'Access-Control-Allow-Origin': '*'
-                },
-                withCredentials: true
+                url: this.props.config.postUrl ? this.props.config.postUrl : null
             };
 
         if (this.props.config.allowedFiletypes && this.props.config.allowedFiletypes.length > 0) {

--- a/lib/dropzone.js
+++ b/lib/dropzone.js
@@ -16,14 +16,7 @@ DropzoneComponent = React.createClass({displayName: "DropzoneComponent",
     getDjsConfig: function () {
         var options,
             defaults = {
-                url: this.props.config.postUrl ? this.props.config.postUrl : null,
-                headers: {
-                    'Access-Control-Allow-Credentials': true,
-                    'Access-Control-Allow-Headers': 'Content-Type, X-Requested-With, X-PINGOTHER, X-File-Name, Cache-Control',
-                    'Access-Control-Allow-Methods': 'PUT, POST, GET, OPTIONS',
-                    'Access-Control-Allow-Origin': '*'
-                },
-                withCredentials: true
+                url: this.props.config.postUrl ? this.props.config.postUrl : null
             };
 
         if (this.props.config.allowedFiletypes && this.props.config.allowedFiletypes.length > 0) {

--- a/src/dropzone.js
+++ b/src/dropzone.js
@@ -16,14 +16,7 @@ DropzoneComponent = React.createClass({
     getDjsConfig: function () {
         var options,
             defaults = {
-                url: this.props.config.postUrl ? this.props.config.postUrl : null,
-                headers: {
-                    'Access-Control-Allow-Credentials': true,
-                    'Access-Control-Allow-Headers': 'Content-Type, X-Requested-With, X-PINGOTHER, X-File-Name, Cache-Control',
-                    'Access-Control-Allow-Methods': 'PUT, POST, GET, OPTIONS',
-                    'Access-Control-Allow-Origin': '*'
-                },
-                withCredentials: true
+                url: this.props.config.postUrl ? this.props.config.postUrl : null
             };
 
         if (this.props.config.allowedFiletypes && this.props.config.allowedFiletypes.length > 0) {


### PR DESCRIPTION
this probably has backward compatibility concerns, but removing these settings allows unsigned cloudinary upload to function correctly.