### PR TITLE
Allow for custom dropzone area

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,24 @@ var componentConfig = {
 ReactDOM.render(<DropzoneComponent config={componentConfig} djsConfig={djsConfig} />, document.getElementById('content'));
 ```
 
+### Custom Dropzone Area
+
+In case you need to customize the dropzone area, you may pass a jQuery compatible selector in the config object.
+
+```js
+var componentConfig = {
+    postUrl: '/uploadHandler',
+    dropzoneSelector: 'body',
+};
+
+ReactDOM.render(
+  <DropzoneComponent config={componentConfig} />,
+  document.getElementById('content'),
+);
+```
+
+The code above will use the entire page `body` as the dropzone area.
+
 ### Callbacks
 Callbacks can be provided in an object literal.
 

--- a/src/__tests__/react-dropzone-test.js
+++ b/src/__tests__/react-dropzone-test.js
@@ -79,4 +79,15 @@ describe('Dropzone Comoponent', () => {
 
         expect(eventHandler).toBeCalled();
     });
+
+    it('Allows custom dropzone areas', () => {
+        let dropzone = TestUtils.renderIntoDocument(
+            <DropzoneComponent config={{
+                ...componentConfig,
+                dropzoneSelector: 'body'
+            }} />
+        );
+
+        expect(document.body.dropzone).toBeDefined()
+    });
 });

--- a/src/react-dropzone.js
+++ b/src/react-dropzone.js
@@ -55,7 +55,8 @@ DropzoneComponent = React.createClass({
             console.info('Neither postUrl nor a "drop" eventHandler specified, the React-Dropzone component might misbehave.');
         }
 
-        this.dropzone = new Dropzone(ReactDOM.findDOMNode(self), options);
+        var dropzoneNode = this.props.config.dropzoneSelector || ReactDOM.findDOMNode(this);
+        this.dropzone = new Dropzone(dropzoneNode, options);
         this.setupEvents();
     },
 
@@ -97,7 +98,8 @@ DropzoneComponent = React.createClass({
         this.queueDestroy = false;
 
         if (!this.dropzone) {
-            this.dropzone = new Dropzone(ReactDOM.findDOMNode(this), this.getDjsConfig());
+            var dropzoneNode = this.props.config.dropzoneSelector || ReactDOM.findDOMNode(this);
+            this.dropzone = new Dropzone(dropzoneNode, this.getDjsConfig());
         }
     },
 


### PR DESCRIPTION
This PR is related to felixrieseberg/React-Dropzone-Component/pull/102.

It essentially allows customizing the dropzone area by passing a jquery compatible selector in the config object.