### PR TITLE
Add latest babel preset for examples.

### DIFF
--- a/example/.babelrc
+++ b/example/.babelrc
@@ -1,0 +1,1 @@
+{ "presets": ["latest"] }

--- a/example/package.json
+++ b/example/package.json
@@ -23,6 +23,7 @@
     "babel-core": "^6.14.0",
     "babel-loader": "^6.2.5",
     "babel-preset-es2015": "^6.14.0",
+    "babel-preset-latest": "^6.22.0",
     "babel-preset-react": "^6.11.1",
     "webpack": "^1.13.2"
   }


### PR DESCRIPTION
Hi,

I encountered a failure in building the client side of the examples directory when running ```npm run start```. Particularly, in the webpack step. 

# Problem

The error is below:

```
$ npm run start

> react-dropzone-component-example@1.0.0 start /Users/kenko/src/React-Dropzone-Component/example
> npm run copy-dropzone && webpack && node server.js


> react-dropzone-component-example@1.0.0 copy-dropzone /Users/kenko/src/React-Dropzone-Component/example
> node build.js

Hash: c49aabece910e105ec7a
Version: webpack 1.14.0
Time: 314ms
    + 1 hidden modules

ERROR in ./src/examples.jsx
Module build failed: Error: Couldn't find preset "latest" relative to directory "/Users/kenko/src"
    at /Users/kenko/src/React-Dropzone-Component/example/node_modules/babel-core/lib/transformation/file/options/option-manager.js:293:19
    at Array.map (native)
    at OptionManager.resolvePresets (/Users/kenko/src/React-Dropzone-Component/example/node_modules/babel-core/lib/transformation/file/options/option-manager.js:275:20)
    at OptionManager.mergePresets (/Users/kenko/src/React-Dropzone-Component/example/node_modules/babel-core/lib/transformation/file/options/option-manager.js:264:10)
    at OptionManager.mergeOptions (/Users/kenko/src/React-Dropzone-Component/example/node_modules/babel-core/lib/transformation/file/options/option-manager.js:249:14)
    at OptionManager.init (/Users/kenko/src/React-Dropzone-Component/example/node_modules/babel-core/lib/transformation/file/options/option-manager.js:368:12)
    at File.initOptions (/Users/kenko/src/React-Dropzone-Component/example/node_modules/babel-core/lib/transformation/file/index.js:216:65)
    at new File (/Users/kenko/src/React-Dropzone-Component/example/node_modules/babel-core/lib/transformation/file/index.js:139:24)
    at Pipeline.transform (/Users/kenko/src/React-Dropzone-Component/example/node_modules/babel-core/lib/transformation/pipeline.js:46:16)
    at transpile (/Users/kenko/src/React-Dropzone-Component/example/node_modules/babel-loader/lib/index.js:46:20)
    at Object.module.exports (/Users/kenko/src/React-Dropzone-Component/example/node_modules/babel-loader/lib/index.js:134:16)
Express server listening on port 3000
Visit http://localhost:3000/example/ to check out the upload example
```

Without any real knowledge about webpack, it appears to me that we are trying to "pack" or include files within the ```examples/node_modules``` directory for whatever reason. The webpack configuration in ```webpack.config.js```, however, excludes any loaders within the ```node_modules``` subdirectory. At least, that's my limited understanding of it. 

# Resolution

Anyhow, the following changes appeared to have resolved my issue. They are basically the [first two steps](https://babeljs.io/docs/plugins/preset-latest/) found in the babeljs documentation regarding the ```latest``` preset.

The output from an ```npm run start``` after the fix is as expected:

```
$ npm run start

> react-dropzone-component-example@1.0.0 start /Users/kenko/src/React-Dropzone-Component/example
> npm run copy-dropzone && webpack && node server.js


> react-dropzone-component-example@1.0.0 copy-dropzone /Users/kenko/src/React-Dropzone-Component/example
> node build.js

Hash: c06ce6aaf765cf37230d
Version: webpack 1.14.0
Time: 1893ms
            Asset    Size  Chunks             Chunk Names
./built/bundle.js  839 kB       0  [emitted]  main
    + 187 hidden modules
Express server listening on port 3000
Visit http://localhost:3000/example/ to check out the upload example
```

# Reproduction

The steps to reproducing this are:

```
git clone git@github.com:felixrieseberg/React-Dropzone-Component.git
cd React-Dropzone-Component/example/
npm i
npm run start
```

However, I was unable to debug why the ```latest``` preset was being searched for, in the first place.