### PR TITLE
Redirect stylesheet from parent to example dir.

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -5,7 +5,7 @@
         <title>React Dropzone Example</title>
         <link rel="stylesheet" type="text/css" href="./styles/example.css" />
         <link rel="stylesheet" type="text/css" href="../styles/filepicker.css" />
-        <link rel="stylesheet" type="text/css" href="../node_modules/dropzone/dist/min/dropzone.min.css" />
+        <link rel="stylesheet" type="text/css" href="./node_modules/dropzone/dist/min/dropzone.min.css" />
     </head>
     <body>
         <div id="host"></div>


### PR DESCRIPTION
# Summary

Because the example/package.json exists and includes
dropzone as a dependency, it will include the dropzone.min.css
that we are including in example/index.html. There's no reason
to include dropzone.min.css from the parent directory, as
that shouldn't be an implicit dependency.

# Problem

I noticed in Chrome Developer Tools that there was a failure in finding the ```dropbox.min.css``` stylesheet. A screen cap is attached below:

<img width="1117" alt="screen shot 2017-02-28 at 2 30 18 am" src="https://cloud.githubusercontent.com/assets/142929/23402288/c5083ca6-fd5f-11e6-9109-33e61da2bf02.png">

# Resolution

After applying this fix, the error doesn't occur anymore. Below is another screenshot of Chrome Developer Tools:

<img width="1104" alt="screen shot 2017-02-28 at 2 31 09 am" src="https://cloud.githubusercontent.com/assets/142929/23402323/eca1c43a-fd5f-11e6-9cb9-cd03b5e2745b.png">
