### PR TITLE
Success Callback has response

### DIFF
--- a/typescript/types.d.ts
+++ b/typescript/types.d.ts
@@ -14,6 +14,8 @@ type UploadProgressCallback = (file: Dropzone.DropzoneFile, progress: number, by
 type TotalUploadProgressCallback = (totalProgress: number, totalBytes: number, totalBytesSent: number) => any;
 type SendingCallback = (file: Dropzone.DropzoneFile, xhr: XMLHttpRequest, formData: FormData) => any;
 type SendingMultipleCallback = (files: Dropzone.DropzoneFile[], xhr: XMLHttpRequest, formData: FormData) => any;
+type SuccessCallback = (file: Dropzone.DropzoneFile, response: Object | string) => any;
+type SuccessMultipleCallback = (files: Dropzone.DropzoneFile[], responseText: string) => any;
 
 /* handlers based on ts definitions for Dropzone.js (@types/dropzone) */
 export declare interface DropzoneComponentHandlers {
@@ -47,8 +49,8 @@ export declare interface DropzoneComponentHandlers {
     sending?: SendingCallback | SendingCallback[];
     sendingmultiple?: SendingMultipleCallback | SendingMultipleCallback[];
 
-    success?: FileCallback | FileCallback[];
-    successmultiple?: FileArrayCallback | FileArrayCallback[];
+    success?: SuccessCallback | SuccessCallback[];
+    successmultiple?: SuccessMultipleCallback | SuccessMultipleCallback[];
 
     canceled?: FileCallback | FileCallback[];
     canceledmultiple?: FileArrayCallback | FileArrayCallback[];


### PR DESCRIPTION
success has a response as the second argument

When using success
```js
eventHandlers = {
    // ...
    success: (file, response) => {
        console.log({file, response});
    },
}
```
I was running into this error
```
TS2322: Type '{ children: string; config: { postUrl: any; }; djsConfig: { maxFilesize: number; maxFiles: number...' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<DropzoneComponent> & Readonly<{ children?: ReactNo...'.
  Type '{ children: string; config: { postUrl: any; }; djsConfig: { maxFilesize: number; maxFiles: number...' is not assignable to type 'Readonly<DropzoneComponentProps>'.
    Types of property 'eventHandlers' are incompatible.
      Type '{ totaluploadprogress: (totalBytes: any, totalBytesSent: any) => void; error: (file: any, respons...' is not assignable to type 'DropzoneComponentHandlers'.
        Types of property 'success' are incompatible.
          Type '(file: any, response: any) => void' is not assignable to type 'FileCallback | FileCallback[]'.
            Type '(file: any, response: any) => void' is not assignable to type 'FileCallback[]'.
              Property 'includes' is missing in type '(file: any, response: any) => void'.
```