### PR TITLE
Updated Dropzone to 5.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1911,9 +1911,9 @@
       }
     },
     "dropzone": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/dropzone/-/dropzone-5.2.0.tgz",
-      "integrity": "sha1-L99qxkcvTGLQPT6fwiqqAinSmd4="
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/dropzone/-/dropzone-5.4.0.tgz",
+      "integrity": "sha1-MpDAf1mxietaEemaWMmyra5az+w="
     },
     "duplexify": {
       "version": "3.5.1",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "uglifyjs-webpack-plugin": "^1.1.6"
   },
   "dependencies": {
-    "dropzone": "^5.2.0",
+    "dropzone": "^5.4.0",
     "extend": "^3.0.1"
   },
   "scripts": {


### PR DESCRIPTION
Safari and IE drag and drop is broke before v5.3.0

This allows the component to work.

Issue: https://github.com/felixrieseberg/React-Dropzone-Component/issues/155