### PR TITLE
Typescript improvement for inheriting from DropzoneComponent

### DIFF
--- a/typescript/types.d.ts
+++ b/typescript/types.d.ts
@@ -79,5 +79,5 @@ interface DropzoneComponentProps {
     action?: string;
 }
 
-export declare class DropzoneComponent extends React.Component<DropzoneComponentProps, {}> {
+export declare class DropzoneComponent<T extends DropzoneComponentProps> extends React.Component<T, {}> {
 }


### PR DESCRIPTION
Made DropzoneComponent type generic over T extends DropzoneComponentProps, so it's possible to inherit from DropzoneComponent while extending the props for the subclass.